### PR TITLE
Fixing MatplotLib deprecated join function

### DIFF
--- a/04-Time-Series-Decomposition/06-MSTL-decomposition.ipynb
+++ b/04-Time-Series-Decomposition/06-MSTL-decomposition.ipynb
@@ -652,7 +652,7 @@
     "ax_last.xaxis.set_ticks(pd.date_range(start=\"2012-01-01\", freq=\"MS\", periods=5))\n",
     "plt.setp(ax_last.get_xticklabels(), rotation=0, horizontalalignment=\"center\")\n",
     "for ax in axs[:-1]:\n",
-    "    ax.get_shared_x_axes().join(ax, ax_last)\n",
+    "    ax.get_shared_x_axes().joined(ax, ax_last)\n",
     "    ax.xaxis.set_ticks(pd.date_range(start=\"2012-01-01\", freq=\"MS\", periods=5))\n",
     "    ax.set_xticklabels([])\n",
     "axs[0].set_ylabel(\"y\")\n",


### PR DESCRIPTION
"MatplotlibDeprecationWarning: The join function was deprecated in "Matplotlib 3.6 and will be removed two minor releases later.