### PR TITLE
str replacing `.` with `:` fails when regex=True

### DIFF
--- a/01-Create-Datasets/03-create-air-quality-dataset.ipynb
+++ b/01-Create-Datasets/03-create-air-quality-dataset.ipynb
@@ -729,7 +729,7 @@
     "# cast date and time variable as datetime\n",
     "# replace . by : to transform to datetime format\n",
     "\n",
-    "data['Date_Time'] = data['Date_Time'].str.replace('.', ':', regex=True)\n",
+    "data['Date_Time'] = data['Date_Time'].str.replace('.', ':', regex=False)\n",
     "\n",
     "data['Date_Time'] = pd.to_datetime(data['Date_Time'])\n",
     "# use dayfirst=True parameter if format is dd/mm/yyyy HH:mm:ss Eg: pd.to_datetime(data['Date_Time'], dayfirst=True)\n",


### PR DESCRIPTION
Running
`data['Date_Time'].str.replace('.', ':', regex=True)`

Changes rows from looking like
`10/03/2004 18.00.00`
to
`:::::::::::::::::::`

throwing an exception when running `pd_to_datetime`:

DateParseError: Unknown datetime string format, unable to parse: :::::::::::::::::::, at position 0


Changing regex=False fixes this.